### PR TITLE
Fixed not existing version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.19.21
+boto3>=1.17.21
 botocore>=1.20.21
 certifi>=2020.12.5
 chardet>=4.0.0


### PR DESCRIPTION
Version does not exist yet and thus creates an endless loop when trying to install the requirements via pip.